### PR TITLE
Add default user for FE lessons

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -12,7 +12,7 @@ class GraphqlController < ApplicationController
     query = params[:query]
     operation_name = params[:operationName]
     context = {
-      current_user: current_user
+      current_user: current_user || User.find_by(email: "default@example.com")
     }
     result = TaskTrackerSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,4 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+User.create(first_name: "Default User", email: "default@example.com", password: "123456")


### PR DESCRIPTION
### Summary

Added default user for FE lessons (they doesn't need authentication).

### How it works

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/35406008/219852930-b3219574-38f5-456a-a19b-4553a0abd7fa.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/35406008/219852943-15d98b07-c49d-4eaa-af18-5d740cb85dea.png">

### Test plan

List of steps to manually test introduced functionality:

- Run `rails db:seed`
- Go to http://localhost:3000/graphiql
- Make request using schema:
```graphql
mutation {
  createProject(input: { name: "Project #1" }) {
    errors {
      message
      path
    }
    project {
      createdAt
      description
      id
      name
      updatedAt
    }
  }
}
```
* Make sure project has been created by default user

### Deploy notes

Run `rails db:seed`

### Checklist:

- [x] I have performed a self-review of my own code
- [x] My pull request is shorter than 500 lines
